### PR TITLE
Fix draft posts showing in blog listing page

### DIFF
--- a/src/pages/[...lang]/posts/[...page].astro
+++ b/src/pages/[...lang]/posts/[...page].astro
@@ -17,9 +17,14 @@ export const getStaticPaths = (async ({ paginate }) => {
   return (
     await Promise.all(
       Object.keys(languages).flatMap(async (lang) => {
-        const posts = (await getCollection("posts"))
-          .filter((post) => post.id.split("/")[0] === lang)
-          .sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime());
+        const posts = (
+          await getCollection(
+            "posts",
+            ({ data: { draft }, id }) =>
+              (draft === false || import.meta.env.DEV) &&
+              id.startsWith(lang),
+          )
+        ).sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime());
 
         return paginate(posts, {
           pageSize: 20,


### PR DESCRIPTION
The blog listing page was not filtering out posts with draft: true,
unlike the home page which correctly excludes them outside of dev mode.

https://claude.ai/code/session_01GJQuMmbJJnFb6HLGC5M9no