### PR TITLE
Fix draft posts visibility in blog section and direct URLs

### DIFF
--- a/src/pages/[...lang]/posts/[...slug].astro
+++ b/src/pages/[...lang]/posts/[...slug].astro
@@ -17,7 +17,10 @@ import type { ImageMetadata } from "astro";
 import { getImage } from "astro:assets";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("posts");
+  const posts = await getCollection(
+    "posts",
+    ({ data: { draft } }) => draft === false || import.meta.env.DEV,
+  );
   return posts.map((post) => {
     const { id } = post;
 

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -41,6 +41,33 @@ async function checkNoConsoleErrors(page: Page, url: string) {
   return errors;
 }
 
+const DRAFT_POSTS = [
+  {
+    url: "/en/posts/oscilloscope-for-newbies-i-probes-and-scales/",
+    title: "Oscilloscope for newbies I: probes and scales",
+    listUrl: "/en/posts/",
+    label: "EN draft: Oscilloscope",
+  },
+  {
+    url: "/posts/osciloscopio-para-principiantes-i-sondas-y-escalas/",
+    title: "Osciloscopio para principiantes I",
+    listUrl: "/posts/",
+    label: "ES draft: Osciloscopio",
+  },
+];
+
+for (const { url, title, listUrl, label } of DRAFT_POSTS) {
+  test(`${label} — direct URL returns 404`, async ({ page }) => {
+    const response = await page.goto(url);
+    expect(response?.status(), `Expected 404 for draft post ${url}`).toBe(404);
+  });
+
+  test(`${label} — not listed in blog section`, async ({ page }) => {
+    await page.goto(listUrl);
+    await expect(page.getByText(title, { exact: false })).not.toBeVisible();
+  });
+}
+
 for (const { url, label } of ROUTES) {
   test(`${label} — HTTP 200`, async ({ page }) => {
     const response = await page.goto(url);


### PR DESCRIPTION
## Summary

- Blog listing page (`[...page].astro`) was fetching all posts without filtering `draft: true`, causing draft posts to appear in the blog section.
- Post detail page (`[...slug].astro`) was generating static routes for all posts including drafts, making them accessible via direct URL.

Both pages now apply the same `draft === false || import.meta.env.DEV` filter already used on the home page — draft posts are hidden in production but remain visible during local development.