### PR TITLE
fix: fix chat avatar image cropped in Safari

### DIFF
--- a/src/components/AuthorNote.astro
+++ b/src/components/AuthorNote.astro
@@ -19,9 +19,9 @@ if (!images[author.data.image!]) throw new Error(`"${author.data.image!}" does n
 
 {
   notes.map((note) => (
-    <div class="chat chat-start">
-      <div class="chat-image avatar">
-        <div class="w-10 rounded-full">
+    <div class="chat chat-start not-prose">
+      <div class="chat-image avatar [grid-row:2/3]">
+        <div class="w-10 h-10 rounded-full">
           <Image src={images[author.data.image!]()} alt={author.data.name} width="40" class="m-0"/>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- The Tailwind Typography `.prose img` rule was applying `margin-top: 2em` (36px) to the avatar image inside the chat component, pushing it down within its 40px `overflow: hidden` circular container — leaving only ~4px visible (a thin white arc at the bottom-left of the bubble).
- Added `not-prose` to the chat container to exclude it from prose image margin rules.
- Added `h-10` to the avatar inner div to provide explicit height, working around a Safari bug where `aspect-ratio: 1` + `overflow: hidden` can collapse without it.
- Added `[grid-row:2/3]` to override DaisyUI's ambiguous `grid-row: span 2/span 2` placement that Safari can misinterpret.